### PR TITLE
Add PHP info, GET, and POST endpoints

### DIFF
--- a/app/Http/Controllers/InfoController.php
+++ b/app/Http/Controllers/InfoController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class InfoController extends Controller
+{
+    /**
+     * Display PHP information.
+     *
+     * @return void
+     */
+    public function showPhpInfo()
+    {
+        phpinfo();
+    }
+
+    /**
+     * Handle a GET request.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function handleGetRequest()
+    {
+        return response()->json(['message' => 'This is a GET request.']);
+    }
+
+    /**
+     * Handle a POST request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function handlePostRequest(Request $request)
+    {
+        return response()->json([
+            'message' => 'This is a POST request.',
+            'data_received' => $request->all()
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\InfoController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/info/php', [InfoController::class, 'showPhpInfo']);
+Route::get('/info/get', [InfoController::class, 'handleGetRequest']);
+Route::post('/info/post', [InfoController::class, 'handlePostRequest']);


### PR DESCRIPTION
This commit introduces a new InfoController with three endpoints:
- /info/php: Displays the output of phpinfo().
- /info/get: A simple GET endpoint returning a JSON message.
- /info/post: A simple POST endpoint returning a JSON message, including any data you send in the request.

Routes for these endpoints have been added to routes/web.php.